### PR TITLE
Revert the app label back to "sendgrid."

### DIFF
--- a/django_sendgrid_webhook/apps.py
+++ b/django_sendgrid_webhook/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+class DjangoSendgridWebhook(AppConfig):
+    name = "django_sendgrid_webhook"
+    verbose_name = "Django Sendgrid Webhook"
+    label = "sendgrid"

--- a/django_sendgrid_webhook/migrations/0002_email_reason.py
+++ b/django_sendgrid_webhook/migrations/0002_email_reason.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('django_sendgrid_webhook', '0001_initial'),
+        ('sendgrid', '0001_initial'),
     ]
 
     operations = [

--- a/django_sendgrid_webhook/migrations/0003_auto_20190722_1007.py
+++ b/django_sendgrid_webhook/migrations/0003_auto_20190722_1007.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('django_sendgrid_webhook', '0002_email_reason'),
+        ('sendgrid', '0002_email_reason'),
     ]
 
     operations = [

--- a/django_sendgrid_webhook/migrations/0004_alter_email_index_together.py
+++ b/django_sendgrid_webhook/migrations/0004_alter_email_index_together.py
@@ -7,7 +7,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('contenttypes', '0002_remove_content_type_name'),
-        ('django_sendgrid_webhook', '0003_auto_20190722_1007'),
+        ('sendgrid', '0003_auto_20190722_1007'),
     ]
 
     operations = [


### PR DESCRIPTION
The only thing we technically needed to solve our original problem (https://github.com/resmio/django-sendgrid/issues/23) was to change the python _module name_ - not the Django app name.

Because there was previously no explicit app config, the app label name was implicitly changed when we renamed the python module.  This was problematic as previous migrations depended on the original `sendgrid` app migrations.

This adds an app config which retains the original Django app name so that we don't need to modify references to the app name in migrations or in the database.

## Review notes

If the build [for this commit](https://github.com/healthvana/h/pull/6968/commits/a11fcddc02388b66a3079159be3ff334cd7a6425) passes, then we should merge this.