### PR TITLE
Address deprecation warnings and allow for open->click

### DIFF
--- a/django_sendgrid_webhook/tests/test_views.py
+++ b/django_sendgrid_webhook/tests/test_views.py
@@ -156,6 +156,51 @@ class ViewTestCase(BaseTest):
         self.assertEqual(models.Email.objects.count(), 1)
         self.assertEqual(models.Email.objects.all()[0].event, 'delivered')
 
+        # simulate next callback by sendgrid
+        response = self.client.post('/sendgrid_callback/',
+                                    data=json.dumps([{
+                                        'email': 'other_email@example.com',
+                                        'uuid': message.uuid,
+                                        'event': 'open',
+                                        'timestamp': '123459999',
+                                    }, ]),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        # this should have modified the existing email model
+        self.assertEqual(models.Email.objects.count(), 1)
+        self.assertEqual(models.Email.objects.all()[0].event, 'open')
+
+        # simulate next callback by sendgrid
+        response = self.client.post('/sendgrid_callback/',
+                                    data=json.dumps([{
+                                        'email': 'other_email@example.com',
+                                        'uuid': message.uuid,
+                                        'event': 'click',
+                                        'timestamp': '123459999',
+                                    }, ]),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        # this should have modified the existing email model
+        self.assertEqual(models.Email.objects.count(), 1)
+        self.assertEqual(models.Email.objects.all()[0].event, 'click')
+
+        # simulate next callback by sendgrid
+        response = self.client.post('/sendgrid_callback/',
+                                    data=json.dumps([{
+                                        'email': 'other_email@example.com',
+                                        'uuid': message.uuid,
+                                        'event': 'open',
+                                        'timestamp': '123459999',
+                                    }, ]),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        # this should NOT have modified the existing email model
+        self.assertEqual(models.Email.objects.count(), 1)
+        self.assertEqual(models.Email.objects.all()[0].event, 'click')
+
     def test_null_reason(self):
         """ Test what happens if we send a null value as a reason, opposed to a missing reason.
         """

--- a/django_sendgrid_webhook/utils.py
+++ b/django_sendgrid_webhook/utils.py
@@ -3,9 +3,8 @@ import json
 
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.conf import settings
-from django.utils.timezone import utc
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .models import Email
 
@@ -36,7 +35,7 @@ class SendgridEmailMessage(EmailMessage):
     def send(self, fail_silently=False):
         ret = super(SendgridEmailMessage, self).send(fail_silently)
         if settings.USE_TZ:
-            now = datetime.utcnow().replace(tzinfo=utc)
+            now = datetime.utcnow().replace(tzinfo=timezone.utc)
         else:
             now = datetime.now()
 
@@ -76,7 +75,7 @@ class SendgridEmailMultiAlternatives(EmailMultiAlternatives):
     def send(self, fail_silently=False):
         ret = super(SendgridEmailMultiAlternatives, self).send(fail_silently)
         if settings.USE_TZ:
-            now = datetime.utcnow().replace(tzinfo=utc)
+            now = datetime.utcnow().replace(tzinfo=timezone.utc)
         else:
             now = datetime.now()
 

--- a/django_sendgrid_webhook/views.py
+++ b/django_sendgrid_webhook/views.py
@@ -26,7 +26,7 @@ class SendgridHook(View):
         'delivered': ('open', 'click', 'unsubscribe', 'spamreport'),
         'bounce': (),
         # Sendgrid: Step 4 - Read
-        'open': (),
+        'open': ('click'),
         'click': (),
         'unsubscribe': (),
         'spamreport': (),

--- a/django_sendgrid_webhook/views.py
+++ b/django_sendgrid_webhook/views.py
@@ -5,7 +5,6 @@ from django.views.generic import View
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse
-from django.utils.timezone import utc
 from django.conf import settings
 from django.utils.module_loading import import_string
 
@@ -63,7 +62,7 @@ class SendgridHook(View):
                     #     (or the API got updated)
             timestamp = datetime.datetime.fromtimestamp(int(event['timestamp']))
             if settings.USE_TZ:
-                timestamp = timestamp.utcnow().replace(tzinfo=utc)
+                timestamp = timestamp.utcnow().replace(tzinfo=datetime.timezone.utc)
             email.timestamp = timestamp
             email.save()
             email_event.send(email)


### PR DESCRIPTION
I'm saving the actual upgrade to Django5 for another day! This simply addresses the deprecation warnings (around datetime utc vs django utils utc). Also addressing the state change needed from open -> click with a test case to illustrate what we're looking for. 